### PR TITLE
Feature/episode guid

### DIFF
--- a/models/episode.py
+++ b/models/episode.py
@@ -24,6 +24,13 @@ class Episode(BaseModel):
     # Source: fireside website of each show
     episode: int
 
+    # Episode number padded with 3 zeros. Generated from `episode`
+    episode_padded: str
+
+    # Episode GUID
+    # Source: Fireside json api: `items[n].id`
+    episode_guid: str
+
     # Episode number again, but specifically for Hugo.
     # Need this since we want to have zero padded filenames (e.g. `0042.md`), but no 
     # zero padding in the link to the episdoe (e.g. `https://coder.show/42`).
@@ -32,9 +39,6 @@ class Episode(BaseModel):
     #   https://gohugo.io/content-management/organization/#slug
     # Source: Generated using `episode` above
     slug: str = ""
-
-    # Episode number padded with 3 zeros. Generated from `episode`
-    episode_padded: str
 
     # Source: fireside website of each show
     title: str

--- a/scraper.py
+++ b/scraper.py
@@ -105,6 +105,8 @@ def create_episode(api_episode,
         episode_number = int(api_episode["url"].split("/")[-1])
         episode_number_padded = f"{episode_number:04}"
 
+        episode_guid = api_episode["id"]
+
         output_file = f"{output_dir}/{episode_number_padded}.md"
 
         if not IS_LATEST_ONLY and os.path.isfile(output_file):
@@ -155,6 +157,7 @@ def create_episode(api_episode,
                 show_name=show_config["name"],
                 episode=episode_number,
                 episode_padded=episode_number_padded,
+                episode_guid=episode_guid,
                 title=get_plain_title(api_episode["title"]),
                 description=blurb,
                 date=publish_date,
@@ -738,7 +741,7 @@ def main():
 
 
 if __name__ == "__main__":
-    LOG_LVL = int(os.getenv("LOG_LVL", 20))  # Default to INFO
+    LOG_LVL = int(os.getenv("LOG_LVL", 20))  # Defaults to INFO
     logger.remove()  # Remove default logger
     logger.add(sys.stderr, level=LOG_LVL)
 


### PR DESCRIPTION
- Add `guid` to episodes
- Remove tracking URL prefixes for all links
  - Needed a clean enclosure URL for podverse
  - They could be added later problematically as needed into the RSS or anywhere else
  - The `podcast_alt_file` link (scraped from JB) is set to `null` if it equals to the main link `podcast_file` (less duplicates and 