### PR TITLE
json to hugo pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ venv.bak/
 # Scraped data folder
 data/
 
+# vagrant
+.vagrant/
 
 # Other
 *.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
 FROM python:3.10-alpine
 
-RUN mkdir /data && chown -R 1000:1000 /data
+ENV PIPENV_VENV_IN_PROJECT=1
 
 WORKDIR /scraper
 COPY . .
-RUN chown 1000:1000 ./scraper.py
-RUN pip install -r requirements.txt
+RUN pip install pipenv
+RUN pipenv sync
+RUN mkdir -p /data && chown -R 1000:1000 ./scraper.py .venv/ /data
 
 USER 1000
-CMD [ "python3", "scraper.py" ]
+ENTRYPOINT [ "pipenv", "run" ]
+CMD [ "./scraper.py" ]

--- a/Pipfile
+++ b/Pipfile
@@ -13,6 +13,8 @@ loguru = "*"
 pydantic = "*"
 
 [dev-packages]
+black = "*"
+pylint = "*"
 
 [requires]
 python_version = "3.10"

--- a/Pipfile
+++ b/Pipfile
@@ -11,6 +11,8 @@ pyyaml = "*"
 python-dateutil = "*"
 loguru = "*"
 pydantic = "*"
+python-frontmatter = "*"
+pydantic-yaml = "*"
 
 [dev-packages]
 black = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,18 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+beautifulsoup4 = "*"
+requests = "*"
+html2text = "*"
+pyyaml = "*"
+python-dateutil = "*"
+loguru = "*"
+pydantic = "*"
+
+[dev-packages]
+
+[requires]
+python_version = "3.10"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "7a908f1056609caf78f90c5cb0bde4d6d80ce42199bb265958388675fbfbd8fd"
+            "sha256": "653bf91711ed8991a3cfa11056f3b081d49aec090a2f51efd3c826cacad3d16f"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -39,6 +39,14 @@
             ],
             "markers": "python_full_version >= '3.6.0'",
             "version": "==2.1.0"
+        },
+        "deprecated": {
+            "hashes": [
+                "sha256:43ac5335da90c31c24ba028af536a91d41d53f9e6901ddb021bcc572ce44e38d",
+                "sha256:64756e3e14c8c5eea9795d93c524551432a0be75629f8f29e67ab8caf076c76d"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.2.13"
         },
         "html2text": {
             "hashes": [
@@ -105,6 +113,14 @@
             "index": "pypi",
             "version": "==1.9.1"
         },
+        "pydantic-yaml": {
+            "hashes": [
+                "sha256:324d75c84c068f64fefd5910967a83735231296c8eaba0dd48d721b7eccae8db",
+                "sha256:aea6b108c9dd6e8d55829e24c48741332dd8b2bd14ed5d7e480e75eff2ed4d7b"
+            ],
+            "index": "pypi",
+            "version": "==0.8.0"
+        },
         "python-dateutil": {
             "hashes": [
                 "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
@@ -112,6 +128,14 @@
             ],
             "index": "pypi",
             "version": "==2.8.2"
+        },
+        "python-frontmatter": {
+            "hashes": [
+                "sha256:766ae75f1b301ffc5fe3494339147e0fd80bc3deff3d7590a93991978b579b08",
+                "sha256:e98152e977225ddafea6f01f40b4b0f1de175766322004c826ca99842d19a7cd"
+            ],
+            "index": "pypi",
+            "version": "==1.0.0"
         },
         "pyyaml": {
             "hashes": [
@@ -160,6 +184,14 @@
             "index": "pypi",
             "version": "==2.28.1"
         },
+        "semver": {
+            "hashes": [
+                "sha256:ced8b23dceb22134307c1b8abfa523da14198793d9787ac838e70e29e77458d4",
+                "sha256:fa0fe2722ee1c3f57eac478820c3a5ae2f624af8264cbdf9000c980ff7f75e3f"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.13.0"
+        },
         "six": {
             "hashes": [
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
@@ -176,6 +208,13 @@
             "markers": "python_full_version >= '3.6.0'",
             "version": "==2.3.2.post1"
         },
+        "types-deprecated": {
+            "hashes": [
+                "sha256:53d05621e1d75de537f5a57d93508c8df17e37c07ee60b9fb09d39e1b7586c1e",
+                "sha256:e04ce58929509865359e91dcc38720123262b4cd68fa2a8a90312d50390bb6fa"
+            ],
+            "version": "==1.2.9"
+        },
         "typing-extensions": {
             "hashes": [
                 "sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02",
@@ -191,6 +230,76 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_version < '4'",
             "version": "==1.26.11"
+        },
+        "wrapt": {
+            "hashes": [
+                "sha256:00b6d4ea20a906c0ca56d84f93065b398ab74b927a7a3dbd470f6fc503f95dc3",
+                "sha256:01c205616a89d09827986bc4e859bcabd64f5a0662a7fe95e0d359424e0e071b",
+                "sha256:02b41b633c6261feff8ddd8d11c711df6842aba629fdd3da10249a53211a72c4",
+                "sha256:07f7a7d0f388028b2df1d916e94bbb40624c59b48ecc6cbc232546706fac74c2",
+                "sha256:11871514607b15cfeb87c547a49bca19fde402f32e2b1c24a632506c0a756656",
+                "sha256:1b376b3f4896e7930f1f772ac4b064ac12598d1c38d04907e696cc4d794b43d3",
+                "sha256:21ac0156c4b089b330b7666db40feee30a5d52634cc4560e1905d6529a3897ff",
+                "sha256:257fd78c513e0fb5cdbe058c27a0624c9884e735bbd131935fd49e9fe719d310",
+                "sha256:2b39d38039a1fdad98c87279b48bc5dce2c0ca0d73483b12cb72aa9609278e8a",
+                "sha256:2cf71233a0ed05ccdabe209c606fe0bac7379fdcf687f39b944420d2a09fdb57",
+                "sha256:2fe803deacd09a233e4762a1adcea5db5d31e6be577a43352936179d14d90069",
+                "sha256:3232822c7d98d23895ccc443bbdf57c7412c5a65996c30442ebe6ed3df335383",
+                "sha256:34aa51c45f28ba7f12accd624225e2b1e5a3a45206aa191f6f9aac931d9d56fe",
+                "sha256:36f582d0c6bc99d5f39cd3ac2a9062e57f3cf606ade29a0a0d6b323462f4dd87",
+                "sha256:380a85cf89e0e69b7cfbe2ea9f765f004ff419f34194018a6827ac0e3edfed4d",
+                "sha256:40e7bc81c9e2b2734ea4bc1aceb8a8f0ceaac7c5299bc5d69e37c44d9081d43b",
+                "sha256:43ca3bbbe97af00f49efb06e352eae40434ca9d915906f77def219b88e85d907",
+                "sha256:4fcc4649dc762cddacd193e6b55bc02edca674067f5f98166d7713b193932b7f",
+                "sha256:5a0f54ce2c092aaf439813735584b9537cad479575a09892b8352fea5e988dc0",
+                "sha256:5a9a0d155deafd9448baff28c08e150d9b24ff010e899311ddd63c45c2445e28",
+                "sha256:5b02d65b9ccf0ef6c34cba6cf5bf2aab1bb2f49c6090bafeecc9cd81ad4ea1c1",
+                "sha256:60db23fa423575eeb65ea430cee741acb7c26a1365d103f7b0f6ec412b893853",
+                "sha256:642c2e7a804fcf18c222e1060df25fc210b9c58db7c91416fb055897fc27e8cc",
+                "sha256:6a9a25751acb379b466ff6be78a315e2b439d4c94c1e99cb7266d40a537995d3",
+                "sha256:6b1a564e6cb69922c7fe3a678b9f9a3c54e72b469875aa8018f18b4d1dd1adf3",
+                "sha256:6d323e1554b3d22cfc03cd3243b5bb815a51f5249fdcbb86fda4bf62bab9e164",
+                "sha256:6e743de5e9c3d1b7185870f480587b75b1cb604832e380d64f9504a0535912d1",
+                "sha256:709fe01086a55cf79d20f741f39325018f4df051ef39fe921b1ebe780a66184c",
+                "sha256:7b7c050ae976e286906dd3f26009e117eb000fb2cf3533398c5ad9ccc86867b1",
+                "sha256:7d2872609603cb35ca513d7404a94d6d608fc13211563571117046c9d2bcc3d7",
+                "sha256:7ef58fb89674095bfc57c4069e95d7a31cfdc0939e2a579882ac7d55aadfd2a1",
+                "sha256:80bb5c256f1415f747011dc3604b59bc1f91c6e7150bd7db03b19170ee06b320",
+                "sha256:81b19725065dcb43df02b37e03278c011a09e49757287dca60c5aecdd5a0b8ed",
+                "sha256:833b58d5d0b7e5b9832869f039203389ac7cbf01765639c7309fd50ef619e0b1",
+                "sha256:88bd7b6bd70a5b6803c1abf6bca012f7ed963e58c68d76ee20b9d751c74a3248",
+                "sha256:8ad85f7f4e20964db4daadcab70b47ab05c7c1cf2a7c1e51087bfaa83831854c",
+                "sha256:8c0ce1e99116d5ab21355d8ebe53d9460366704ea38ae4d9f6933188f327b456",
+                "sha256:8d649d616e5c6a678b26d15ece345354f7c2286acd6db868e65fcc5ff7c24a77",
+                "sha256:903500616422a40a98a5a3c4ff4ed9d0066f3b4c951fa286018ecdf0750194ef",
+                "sha256:9736af4641846491aedb3c3f56b9bc5568d92b0692303b5a305301a95dfd38b1",
+                "sha256:988635d122aaf2bdcef9e795435662bcd65b02f4f4c1ae37fbee7401c440b3a7",
+                "sha256:9cca3c2cdadb362116235fdbd411735de4328c61425b0aa9f872fd76d02c4e86",
+                "sha256:9e0fd32e0148dd5dea6af5fee42beb949098564cc23211a88d799e434255a1f4",
+                "sha256:9f3e6f9e05148ff90002b884fbc2a86bd303ae847e472f44ecc06c2cd2fcdb2d",
+                "sha256:a85d2b46be66a71bedde836d9e41859879cc54a2a04fad1191eb50c2066f6e9d",
+                "sha256:a9a52172be0b5aae932bef82a79ec0a0ce87288c7d132946d645eba03f0ad8a8",
+                "sha256:aa31fdcc33fef9eb2552cbcbfee7773d5a6792c137b359e82879c101e98584c5",
+                "sha256:b014c23646a467558be7da3d6b9fa409b2c567d2110599b7cf9a0c5992b3b471",
+                "sha256:b21bb4c09ffabfa0e85e3a6b623e19b80e7acd709b9f91452b8297ace2a8ab00",
+                "sha256:b5901a312f4d14c59918c221323068fad0540e34324925c8475263841dbdfe68",
+                "sha256:b9b7a708dd92306328117d8c4b62e2194d00c365f18eff11a9b53c6f923b01e3",
+                "sha256:d1967f46ea8f2db647c786e78d8cc7e4313dbd1b0aca360592d8027b8508e24d",
+                "sha256:d52a25136894c63de15a35bc0bdc5adb4b0e173b9c0d07a2be9d3ca64a332735",
+                "sha256:d77c85fedff92cf788face9bfa3ebaa364448ebb1d765302e9af11bf449ca36d",
+                "sha256:d79d7d5dc8a32b7093e81e97dad755127ff77bcc899e845f41bf71747af0c569",
+                "sha256:dbcda74c67263139358f4d188ae5faae95c30929281bc6866d00573783c422b7",
+                "sha256:ddaea91abf8b0d13443f6dac52e89051a5063c7d014710dcb4d4abb2ff811a59",
+                "sha256:dee0ce50c6a2dd9056c20db781e9c1cfd33e77d2d569f5d1d9321c641bb903d5",
+                "sha256:dee60e1de1898bde3b238f18340eec6148986da0455d8ba7848d50470a7a32fb",
+                "sha256:e2f83e18fe2f4c9e7db597e988f72712c0c3676d337d8b101f6758107c42425b",
+                "sha256:e3fb1677c720409d5f671e39bac6c9e0e422584e5f518bfd50aa4cbbea02433f",
+                "sha256:ee2b1b1769f6707a8a445162ea16dddf74285c3964f605877a20e38545c3c462",
+                "sha256:ee6acae74a2b91865910eef5e7de37dc6895ad96fa23603d1d27ea69df545015",
+                "sha256:ef3f72c9666bba2bab70d2a8b79f2c6d2c1a42a7f7e2b0ec83bb2f9e383950af"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==1.14.1"
         }
     },
     "develop": {
@@ -338,18 +447,18 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:0d33c374d41c7863419fc8f6c10bfe25b7b498aa34164d135c622e52580c6b16",
-                "sha256:c04b44a57a6265fe34a4a444e965884716d34bae963119a76353434d6f18e450"
+                "sha256:d36f579e989a90e8106b9061599c707d912e9cd296b30d62cb6b4dd3567a5ddc",
+                "sha256:db49784825568c9340e45e3322b8b8aed4ca598ce9bbf5277dcae95cc04dc469"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==63.2.0"
+            "version": "==63.4.0"
         },
         "tomli": {
             "hashes": [
                 "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
                 "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
             ],
-            "markers": "python_version < '3.11'",
+            "markers": "python_full_version < '3.11.0a7'",
             "version": "==2.0.1"
         },
         "tomlkit": {

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d165a33a0d4abd17d84738301e39b121f437edf8b96e1678b64668bd583a81c1"
+            "sha256": "7a908f1056609caf78f90c5cb0bde4d6d80ce42199bb265958388675fbfbd8fd"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -186,12 +186,249 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:8298d6d56d39be0e3bc13c1c97d133f9b45d797169a0e11cdd0e0489d786f7ec",
-                "sha256:879ba4d1e89654d9769ce13121e0f94310ea32e8d2f8cf587b77c08bbcdb30d6"
+                "sha256:c33ccba33c819596124764c23a97d25f32b28433ba0dedeb77d873a38722c9bc",
+                "sha256:ea6e8fb210b19d950fab93b60c9009226c63a28808bc8386e05301e25883ac0a"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_version < '4'",
-            "version": "==1.26.10"
+            "version": "==1.26.11"
         }
     },
-    "develop": {}
+    "develop": {
+        "astroid": {
+            "hashes": [
+                "sha256:86b0a340a512c65abf4368b80252754cda17c02cdbbd3f587dddf98112233e7b",
+                "sha256:bb24615c77f4837c707669d16907331374ae8a964650a66999da3f5ca68dc946"
+            ],
+            "markers": "python_full_version >= '3.6.2'",
+            "version": "==2.11.7"
+        },
+        "black": {
+            "hashes": [
+                "sha256:074458dc2f6e0d3dab7928d4417bb6957bb834434516f21514138437accdbe90",
+                "sha256:187d96c5e713f441a5829e77120c269b6514418f4513a390b0499b0987f2ff1c",
+                "sha256:2ea29072e954a4d55a2ff58971b83365eba5d3d357352a07a7a4df0d95f51c78",
+                "sha256:4af5bc0e1f96be5ae9bd7aaec219c901a94d6caa2484c21983d043371c733fc4",
+                "sha256:560558527e52ce8afba936fcce93a7411ab40c7d5fe8c2463e279e843c0328ee",
+                "sha256:568ac3c465b1c8b34b61cd7a4e349e93f91abf0f9371eda1cf87194663ab684e",
+                "sha256:6797f58943fceb1c461fb572edbe828d811e719c24e03375fd25170ada53825e",
+                "sha256:6c1734ab264b8f7929cef8ae5f900b85d579e6cbfde09d7387da8f04771b51c6",
+                "sha256:6c6d39e28aed379aec40da1c65434c77d75e65bb59a1e1c283de545fb4e7c6c9",
+                "sha256:7ba9be198ecca5031cd78745780d65a3f75a34b2ff9be5837045dce55db83d1c",
+                "sha256:94783f636bca89f11eb5d50437e8e17fbc6a929a628d82304c80fa9cd945f256",
+                "sha256:a218d7e5856f91d20f04e931b6f16d15356db1c846ee55f01bac297a705ca24f",
+                "sha256:a3db5b6409b96d9bd543323b23ef32a1a2b06416d525d27e0f67e74f1446c8f2",
+                "sha256:ac609cf8ef5e7115ddd07d85d988d074ed00e10fbc3445aee393e70164a2219c",
+                "sha256:b154e6bbde1e79ea3260c4b40c0b7b3109ffcdf7bc4ebf8859169a6af72cd70b",
+                "sha256:b270a168d69edb8b7ed32c193ef10fd27844e5c60852039599f9184460ce0807",
+                "sha256:b9fd45787ba8aa3f5e0a0a98920c1012c884622c6c920dbe98dbd05bc7c70fbf",
+                "sha256:c85928b9d5f83b23cee7d0efcb310172412fbf7cb9d9ce963bd67fd141781def",
+                "sha256:c9a3ac16efe9ec7d7381ddebcc022119794872abce99475345c5a61aa18c45ad",
+                "sha256:cfaf3895a9634e882bf9d2363fed5af8888802d670f58b279b0bece00e9a872d",
+                "sha256:e439798f819d49ba1c0bd9664427a05aab79bfba777a6db94fd4e56fae0cb849",
+                "sha256:f586c26118bc6e714ec58c09df0157fe2d9ee195c764f630eb0d8e7ccce72e69",
+                "sha256:f6fe02afde060bbeef044af7996f335fbe90b039ccf3f5eb8f16df8b20f77666"
+            ],
+            "index": "pypi",
+            "version": "==22.6.0"
+        },
+        "click": {
+            "hashes": [
+                "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e",
+                "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==8.1.3"
+        },
+        "dill": {
+            "hashes": [
+                "sha256:33501d03270bbe410c72639b350e941882a8b0fd55357580fbc873fba0c59302",
+                "sha256:d75e41f3eff1eee599d738e76ba8f4ad98ea229db8b085318aa2b3333a208c86"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'",
+            "version": "==0.3.5.1"
+        },
+        "isort": {
+            "hashes": [
+                "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7",
+                "sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951"
+            ],
+            "markers": "python_version < '4.0' and python_full_version >= '3.6.1'",
+            "version": "==5.10.1"
+        },
+        "lazy-object-proxy": {
+            "hashes": [
+                "sha256:043651b6cb706eee4f91854da4a089816a6606c1428fd391573ef8cb642ae4f7",
+                "sha256:07fa44286cda977bd4803b656ffc1c9b7e3bc7dff7d34263446aec8f8c96f88a",
+                "sha256:12f3bb77efe1367b2515f8cb4790a11cffae889148ad33adad07b9b55e0ab22c",
+                "sha256:2052837718516a94940867e16b1bb10edb069ab475c3ad84fd1e1a6dd2c0fcfc",
+                "sha256:2130db8ed69a48a3440103d4a520b89d8a9405f1b06e2cc81640509e8bf6548f",
+                "sha256:39b0e26725c5023757fc1ab2a89ef9d7ab23b84f9251e28f9cc114d5b59c1b09",
+                "sha256:46ff647e76f106bb444b4533bb4153c7370cdf52efc62ccfc1a28bdb3cc95442",
+                "sha256:4dca6244e4121c74cc20542c2ca39e5c4a5027c81d112bfb893cf0790f96f57e",
+                "sha256:553b0f0d8dbf21890dd66edd771f9b1b5f51bd912fa5f26de4449bfc5af5e029",
+                "sha256:677ea950bef409b47e51e733283544ac3d660b709cfce7b187f5ace137960d61",
+                "sha256:6a24357267aa976abab660b1d47a34aaf07259a0c3859a34e536f1ee6e76b5bb",
+                "sha256:6a6e94c7b02641d1311228a102607ecd576f70734dc3d5e22610111aeacba8a0",
+                "sha256:6aff3fe5de0831867092e017cf67e2750c6a1c7d88d84d2481bd84a2e019ec35",
+                "sha256:6ecbb350991d6434e1388bee761ece3260e5228952b1f0c46ffc800eb313ff42",
+                "sha256:7096a5e0c1115ec82641afbdd70451a144558ea5cf564a896294e346eb611be1",
+                "sha256:70ed0c2b380eb6248abdef3cd425fc52f0abd92d2b07ce26359fcbc399f636ad",
+                "sha256:8561da8b3dd22d696244d6d0d5330618c993a215070f473b699e00cf1f3f6443",
+                "sha256:85b232e791f2229a4f55840ed54706110c80c0a210d076eee093f2b2e33e1bfd",
+                "sha256:898322f8d078f2654d275124a8dd19b079080ae977033b713f677afcfc88e2b9",
+                "sha256:8f3953eb575b45480db6568306893f0bd9d8dfeeebd46812aa09ca9579595148",
+                "sha256:91ba172fc5b03978764d1df5144b4ba4ab13290d7bab7a50f12d8117f8630c38",
+                "sha256:9d166602b525bf54ac994cf833c385bfcc341b364e3ee71e3bf5a1336e677b55",
+                "sha256:a57d51ed2997e97f3b8e3500c984db50a554bb5db56c50b5dab1b41339b37e36",
+                "sha256:b9e89b87c707dd769c4ea91f7a31538888aad05c116a59820f28d59b3ebfe25a",
+                "sha256:bb8c5fd1684d60a9902c60ebe276da1f2281a318ca16c1d0a96db28f62e9166b",
+                "sha256:c19814163728941bb871240d45c4c30d33b8a2e85972c44d4e63dd7107faba44",
+                "sha256:c4ce15276a1a14549d7e81c243b887293904ad2d94ad767f42df91e75fd7b5b6",
+                "sha256:c7a683c37a8a24f6428c28c561c80d5f4fd316ddcf0c7cab999b15ab3f5c5c69",
+                "sha256:d609c75b986def706743cdebe5e47553f4a5a1da9c5ff66d76013ef396b5a8a4",
+                "sha256:d66906d5785da8e0be7360912e99c9188b70f52c422f9fc18223347235691a84",
+                "sha256:dd7ed7429dbb6c494aa9bc4e09d94b778a3579be699f9d67da7e6804c422d3de",
+                "sha256:df2631f9d67259dc9620d831384ed7732a198eb434eadf69aea95ad18c587a28",
+                "sha256:e368b7f7eac182a59ff1f81d5f3802161932a41dc1b1cc45c1f757dc876b5d2c",
+                "sha256:e40f2013d96d30217a51eeb1db28c9ac41e9d0ee915ef9d00da639c5b63f01a1",
+                "sha256:f769457a639403073968d118bc70110e7dce294688009f5c24ab78800ae56dc8",
+                "sha256:fccdf7c2c5821a8cbd0a9440a456f5050492f2270bd54e94360cac663398739b",
+                "sha256:fd45683c3caddf83abbb1249b653a266e7069a09f486daa8863fb0e7496a9fdb"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.7.1"
+        },
+        "mccabe": {
+            "hashes": [
+                "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325",
+                "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==0.7.0"
+        },
+        "mypy-extensions": {
+            "hashes": [
+                "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d",
+                "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"
+            ],
+            "version": "==0.4.3"
+        },
+        "pathspec": {
+            "hashes": [
+                "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a",
+                "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"
+            ],
+            "version": "==0.9.0"
+        },
+        "platformdirs": {
+            "hashes": [
+                "sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788",
+                "sha256:58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.5.2"
+        },
+        "pylint": {
+            "hashes": [
+                "sha256:487ce2192eee48211269a0e976421f334cf94de1806ca9d0a99449adcdf0285e",
+                "sha256:fabe30000de7d07636d2e82c9a518ad5ad7908590fe135ace169b44839c15f90"
+            ],
+            "index": "pypi",
+            "version": "==2.14.5"
+        },
+        "setuptools": {
+            "hashes": [
+                "sha256:0d33c374d41c7863419fc8f6c10bfe25b7b498aa34164d135c622e52580c6b16",
+                "sha256:c04b44a57a6265fe34a4a444e965884716d34bae963119a76353434d6f18e450"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==63.2.0"
+        },
+        "tomli": {
+            "hashes": [
+                "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+                "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
+            ],
+            "markers": "python_version < '3.11'",
+            "version": "==2.0.1"
+        },
+        "tomlkit": {
+            "hashes": [
+                "sha256:1c5bebdf19d5051e2e1de6cf70adfc5948d47221f097fcff7a3ffc91e953eaf5",
+                "sha256:61901f81ff4017951119cd0d1ed9b7af31c821d6845c8c477587bbdcd5e5854e"
+            ],
+            "markers": "python_version >= '3.6' and python_version < '4.0'",
+            "version": "==0.11.1"
+        },
+        "wrapt": {
+            "hashes": [
+                "sha256:00b6d4ea20a906c0ca56d84f93065b398ab74b927a7a3dbd470f6fc503f95dc3",
+                "sha256:01c205616a89d09827986bc4e859bcabd64f5a0662a7fe95e0d359424e0e071b",
+                "sha256:02b41b633c6261feff8ddd8d11c711df6842aba629fdd3da10249a53211a72c4",
+                "sha256:07f7a7d0f388028b2df1d916e94bbb40624c59b48ecc6cbc232546706fac74c2",
+                "sha256:11871514607b15cfeb87c547a49bca19fde402f32e2b1c24a632506c0a756656",
+                "sha256:1b376b3f4896e7930f1f772ac4b064ac12598d1c38d04907e696cc4d794b43d3",
+                "sha256:21ac0156c4b089b330b7666db40feee30a5d52634cc4560e1905d6529a3897ff",
+                "sha256:257fd78c513e0fb5cdbe058c27a0624c9884e735bbd131935fd49e9fe719d310",
+                "sha256:2b39d38039a1fdad98c87279b48bc5dce2c0ca0d73483b12cb72aa9609278e8a",
+                "sha256:2cf71233a0ed05ccdabe209c606fe0bac7379fdcf687f39b944420d2a09fdb57",
+                "sha256:2fe803deacd09a233e4762a1adcea5db5d31e6be577a43352936179d14d90069",
+                "sha256:3232822c7d98d23895ccc443bbdf57c7412c5a65996c30442ebe6ed3df335383",
+                "sha256:34aa51c45f28ba7f12accd624225e2b1e5a3a45206aa191f6f9aac931d9d56fe",
+                "sha256:36f582d0c6bc99d5f39cd3ac2a9062e57f3cf606ade29a0a0d6b323462f4dd87",
+                "sha256:380a85cf89e0e69b7cfbe2ea9f765f004ff419f34194018a6827ac0e3edfed4d",
+                "sha256:40e7bc81c9e2b2734ea4bc1aceb8a8f0ceaac7c5299bc5d69e37c44d9081d43b",
+                "sha256:43ca3bbbe97af00f49efb06e352eae40434ca9d915906f77def219b88e85d907",
+                "sha256:4fcc4649dc762cddacd193e6b55bc02edca674067f5f98166d7713b193932b7f",
+                "sha256:5a0f54ce2c092aaf439813735584b9537cad479575a09892b8352fea5e988dc0",
+                "sha256:5a9a0d155deafd9448baff28c08e150d9b24ff010e899311ddd63c45c2445e28",
+                "sha256:5b02d65b9ccf0ef6c34cba6cf5bf2aab1bb2f49c6090bafeecc9cd81ad4ea1c1",
+                "sha256:60db23fa423575eeb65ea430cee741acb7c26a1365d103f7b0f6ec412b893853",
+                "sha256:642c2e7a804fcf18c222e1060df25fc210b9c58db7c91416fb055897fc27e8cc",
+                "sha256:6a9a25751acb379b466ff6be78a315e2b439d4c94c1e99cb7266d40a537995d3",
+                "sha256:6b1a564e6cb69922c7fe3a678b9f9a3c54e72b469875aa8018f18b4d1dd1adf3",
+                "sha256:6d323e1554b3d22cfc03cd3243b5bb815a51f5249fdcbb86fda4bf62bab9e164",
+                "sha256:6e743de5e9c3d1b7185870f480587b75b1cb604832e380d64f9504a0535912d1",
+                "sha256:709fe01086a55cf79d20f741f39325018f4df051ef39fe921b1ebe780a66184c",
+                "sha256:7b7c050ae976e286906dd3f26009e117eb000fb2cf3533398c5ad9ccc86867b1",
+                "sha256:7d2872609603cb35ca513d7404a94d6d608fc13211563571117046c9d2bcc3d7",
+                "sha256:7ef58fb89674095bfc57c4069e95d7a31cfdc0939e2a579882ac7d55aadfd2a1",
+                "sha256:80bb5c256f1415f747011dc3604b59bc1f91c6e7150bd7db03b19170ee06b320",
+                "sha256:81b19725065dcb43df02b37e03278c011a09e49757287dca60c5aecdd5a0b8ed",
+                "sha256:833b58d5d0b7e5b9832869f039203389ac7cbf01765639c7309fd50ef619e0b1",
+                "sha256:88bd7b6bd70a5b6803c1abf6bca012f7ed963e58c68d76ee20b9d751c74a3248",
+                "sha256:8ad85f7f4e20964db4daadcab70b47ab05c7c1cf2a7c1e51087bfaa83831854c",
+                "sha256:8c0ce1e99116d5ab21355d8ebe53d9460366704ea38ae4d9f6933188f327b456",
+                "sha256:8d649d616e5c6a678b26d15ece345354f7c2286acd6db868e65fcc5ff7c24a77",
+                "sha256:903500616422a40a98a5a3c4ff4ed9d0066f3b4c951fa286018ecdf0750194ef",
+                "sha256:9736af4641846491aedb3c3f56b9bc5568d92b0692303b5a305301a95dfd38b1",
+                "sha256:988635d122aaf2bdcef9e795435662bcd65b02f4f4c1ae37fbee7401c440b3a7",
+                "sha256:9cca3c2cdadb362116235fdbd411735de4328c61425b0aa9f872fd76d02c4e86",
+                "sha256:9e0fd32e0148dd5dea6af5fee42beb949098564cc23211a88d799e434255a1f4",
+                "sha256:9f3e6f9e05148ff90002b884fbc2a86bd303ae847e472f44ecc06c2cd2fcdb2d",
+                "sha256:a85d2b46be66a71bedde836d9e41859879cc54a2a04fad1191eb50c2066f6e9d",
+                "sha256:a9a52172be0b5aae932bef82a79ec0a0ce87288c7d132946d645eba03f0ad8a8",
+                "sha256:aa31fdcc33fef9eb2552cbcbfee7773d5a6792c137b359e82879c101e98584c5",
+                "sha256:b014c23646a467558be7da3d6b9fa409b2c567d2110599b7cf9a0c5992b3b471",
+                "sha256:b21bb4c09ffabfa0e85e3a6b623e19b80e7acd709b9f91452b8297ace2a8ab00",
+                "sha256:b5901a312f4d14c59918c221323068fad0540e34324925c8475263841dbdfe68",
+                "sha256:b9b7a708dd92306328117d8c4b62e2194d00c365f18eff11a9b53c6f923b01e3",
+                "sha256:d1967f46ea8f2db647c786e78d8cc7e4313dbd1b0aca360592d8027b8508e24d",
+                "sha256:d52a25136894c63de15a35bc0bdc5adb4b0e173b9c0d07a2be9d3ca64a332735",
+                "sha256:d77c85fedff92cf788face9bfa3ebaa364448ebb1d765302e9af11bf449ca36d",
+                "sha256:d79d7d5dc8a32b7093e81e97dad755127ff77bcc899e845f41bf71747af0c569",
+                "sha256:dbcda74c67263139358f4d188ae5faae95c30929281bc6866d00573783c422b7",
+                "sha256:ddaea91abf8b0d13443f6dac52e89051a5063c7d014710dcb4d4abb2ff811a59",
+                "sha256:dee0ce50c6a2dd9056c20db781e9c1cfd33e77d2d569f5d1d9321c641bb903d5",
+                "sha256:dee60e1de1898bde3b238f18340eec6148986da0455d8ba7848d50470a7a32fb",
+                "sha256:e2f83e18fe2f4c9e7db597e988f72712c0c3676d337d8b101f6758107c42425b",
+                "sha256:e3fb1677c720409d5f671e39bac6c9e0e422584e5f518bfd50aa4cbbea02433f",
+                "sha256:ee2b1b1769f6707a8a445162ea16dddf74285c3964f605877a20e38545c3c462",
+                "sha256:ee6acae74a2b91865910eef5e7de37dc6895ad96fa23603d1d27ea69df545015",
+                "sha256:ef3f72c9666bba2bab70d2a8b79f2c6d2c1a42a7f7e2b0ec83bb2f9e383950af"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==1.14.1"
+        }
+    }
 }

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,197 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "d165a33a0d4abd17d84738301e39b121f437edf8b96e1678b64668bd583a81c1"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.10"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "beautifulsoup4": {
+            "hashes": [
+                "sha256:58d5c3d29f5a36ffeb94f02f0d786cd53014cf9b3b3951d42e0080d8a9498d30",
+                "sha256:ad9aa55b65ef2808eb405f46cf74df7fcb7044d5cbc26487f96eb2ef2e436693"
+            ],
+            "index": "pypi",
+            "version": "==4.11.1"
+        },
+        "certifi": {
+            "hashes": [
+                "sha256:84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d",
+                "sha256:fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412"
+            ],
+            "markers": "python_full_version >= '3.6.0'",
+            "version": "==2022.6.15"
+        },
+        "charset-normalizer": {
+            "hashes": [
+                "sha256:5189b6f22b01957427f35b6a08d9a0bc45b46d3788ef5a92e978433c7a35f8a5",
+                "sha256:575e708016ff3a5e3681541cb9d79312c416835686d054a23accb873b254f413"
+            ],
+            "markers": "python_full_version >= '3.6.0'",
+            "version": "==2.1.0"
+        },
+        "html2text": {
+            "hashes": [
+                "sha256:c7c629882da0cf377d66f073329ccf34a12ed2adf0169b9285ae4e63ef54c82b",
+                "sha256:e296318e16b059ddb97f7a8a1d6a5c1d7af4544049a01e261731d2d5cc277bbb"
+            ],
+            "index": "pypi",
+            "version": "==2020.1.16"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff",
+                "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==3.3"
+        },
+        "loguru": {
+            "hashes": [
+                "sha256:066bd06758d0a513e9836fd9c6b5a75bfb3fd36841f4b996bc60b547a309d41c",
+                "sha256:4e2414d534a2ab57573365b3e6d0234dfb1d84b68b7f3b948e6fb743860a77c3"
+            ],
+            "index": "pypi",
+            "version": "==0.6.0"
+        },
+        "pydantic": {
+            "hashes": [
+                "sha256:02eefd7087268b711a3ff4db528e9916ac9aa18616da7bca69c1871d0b7a091f",
+                "sha256:059b6c1795170809103a1538255883e1983e5b831faea6558ef873d4955b4a74",
+                "sha256:0bf07cab5b279859c253d26a9194a8906e6f4a210063b84b433cf90a569de0c1",
+                "sha256:1542636a39c4892c4f4fa6270696902acb186a9aaeac6f6cf92ce6ae2e88564b",
+                "sha256:177071dfc0df6248fd22b43036f936cfe2508077a72af0933d0c1fa269b18537",
+                "sha256:18f3e912f9ad1bdec27fb06b8198a2ccc32f201e24174cec1b3424dda605a310",
+                "sha256:1dd8fecbad028cd89d04a46688d2fcc14423e8a196d5b0a5c65105664901f810",
+                "sha256:1ed987c3ff29fff7fd8c3ea3a3ea877ad310aae2ef9889a119e22d3f2db0691a",
+                "sha256:447d5521575f18e18240906beadc58551e97ec98142266e521c34968c76c8761",
+                "sha256:494f7c8537f0c02b740c229af4cb47c0d39840b829ecdcfc93d91dcbb0779892",
+                "sha256:4988c0f13c42bfa9ddd2fe2f569c9d54646ce84adc5de84228cfe83396f3bd58",
+                "sha256:4ce9ae9e91f46c344bec3b03d6ee9612802682c1551aaf627ad24045ce090761",
+                "sha256:5d93d4e95eacd313d2c765ebe40d49ca9dd2ed90e5b37d0d421c597af830c195",
+                "sha256:61b6760b08b7c395975d893e0b814a11cf011ebb24f7d869e7118f5a339a82e1",
+                "sha256:72ccb318bf0c9ab97fc04c10c37683d9eea952ed526707fabf9ac5ae59b701fd",
+                "sha256:79b485767c13788ee314669008d01f9ef3bc05db9ea3298f6a50d3ef596a154b",
+                "sha256:7eb57ba90929bac0b6cc2af2373893d80ac559adda6933e562dcfb375029acee",
+                "sha256:8bc541a405423ce0e51c19f637050acdbdf8feca34150e0d17f675e72d119580",
+                "sha256:969dd06110cb780da01336b281f53e2e7eb3a482831df441fb65dd30403f4608",
+                "sha256:985ceb5d0a86fcaa61e45781e567a59baa0da292d5ed2e490d612d0de5796918",
+                "sha256:9bcf8b6e011be08fb729d110f3e22e654a50f8a826b0575c7196616780683380",
+                "sha256:9ce157d979f742a915b75f792dbd6aa63b8eccaf46a1005ba03aa8a986bde34a",
+                "sha256:9f659a5ee95c8baa2436d392267988fd0f43eb774e5eb8739252e5a7e9cf07e0",
+                "sha256:a4a88dcd6ff8fd47c18b3a3709a89adb39a6373f4482e04c1b765045c7e282fd",
+                "sha256:a955260d47f03df08acf45689bd163ed9df82c0e0124beb4251b1290fa7ae728",
+                "sha256:a9af62e9b5b9bc67b2a195ebc2c2662fdf498a822d62f902bf27cccb52dbbf49",
+                "sha256:ae72f8098acb368d877b210ebe02ba12585e77bd0db78ac04a1ee9b9f5dd2166",
+                "sha256:b83ba3825bc91dfa989d4eed76865e71aea3a6ca1388b59fc801ee04c4d8d0d6",
+                "sha256:c11951b404e08b01b151222a1cb1a9f0a860a8153ce8334149ab9199cd198131",
+                "sha256:c320c64dd876e45254bdd350f0179da737463eea41c43bacbee9d8c9d1021f11",
+                "sha256:c8098a724c2784bf03e8070993f6d46aa2eeca031f8d8a048dff277703e6e193",
+                "sha256:d12f96b5b64bec3f43c8e82b4aab7599d0157f11c798c9f9c528a72b9e0b339a",
+                "sha256:e565a785233c2d03724c4dc55464559639b1ba9ecf091288dd47ad9c629433bd",
+                "sha256:f0f047e11febe5c3198ed346b507e1d010330d56ad615a7e0a89fae604065a0e",
+                "sha256:fe4670cb32ea98ffbf5a1262f14c3e102cccd92b1869df3bb09538158ba90fe6"
+            ],
+            "index": "pypi",
+            "version": "==1.9.1"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
+                "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            ],
+            "index": "pypi",
+            "version": "==2.8.2"
+        },
+        "pyyaml": {
+            "hashes": [
+                "sha256:0283c35a6a9fbf047493e3a0ce8d79ef5030852c51e9d911a27badfde0605293",
+                "sha256:055d937d65826939cb044fc8c9b08889e8c743fdc6a32b33e2390f66013e449b",
+                "sha256:07751360502caac1c067a8132d150cf3d61339af5691fe9e87803040dbc5db57",
+                "sha256:0b4624f379dab24d3725ffde76559cff63d9ec94e1736b556dacdfebe5ab6d4b",
+                "sha256:0ce82d761c532fe4ec3f87fc45688bdd3a4c1dc5e0b4a19814b9009a29baefd4",
+                "sha256:1e4747bc279b4f613a09eb64bba2ba602d8a6664c6ce6396a4d0cd413a50ce07",
+                "sha256:213c60cd50106436cc818accf5baa1aba61c0189ff610f64f4a3e8c6726218ba",
+                "sha256:231710d57adfd809ef5d34183b8ed1eeae3f76459c18fb4a0b373ad56bedcdd9",
+                "sha256:277a0ef2981ca40581a47093e9e2d13b3f1fbbeffae064c1d21bfceba2030287",
+                "sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513",
+                "sha256:40527857252b61eacd1d9af500c3337ba8deb8fc298940291486c465c8b46ec0",
+                "sha256:473f9edb243cb1935ab5a084eb238d842fb8f404ed2193a915d1784b5a6b5fc0",
+                "sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92",
+                "sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f",
+                "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2",
+                "sha256:77f396e6ef4c73fdc33a9157446466f1cff553d979bd00ecb64385760c6babdc",
+                "sha256:819b3830a1543db06c4d4b865e70ded25be52a2e0631ccd2f6a47a2822f2fd7c",
+                "sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86",
+                "sha256:98c4d36e99714e55cfbaaee6dd5badbc9a1ec339ebfc3b1f52e293aee6bb71a4",
+                "sha256:9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c",
+                "sha256:9fa600030013c4de8165339db93d182b9431076eb98eb40ee068700c9c813e34",
+                "sha256:a80a78046a72361de73f8f395f1f1e49f956c6be882eed58505a15f3e430962b",
+                "sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c",
+                "sha256:b5b9eccad747aabaaffbc6064800670f0c297e52c12754eb1d976c57e4f74dcb",
+                "sha256:c5687b8d43cf58545ade1fe3e055f70eac7a5a1a0bf42824308d868289a95737",
+                "sha256:cba8c411ef271aa037d7357a2bc8f9ee8b58b9965831d9e51baf703280dc73d3",
+                "sha256:d15a181d1ecd0d4270dc32edb46f7cb7733c7c508857278d3d378d14d606db2d",
+                "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53",
+                "sha256:d4eccecf9adf6fbcc6861a38015c2a64f38b9d94838ac1810a9023a0609e1b78",
+                "sha256:d67d839ede4ed1b28a4e8909735fc992a923cdb84e618544973d7dfc71540803",
+                "sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a",
+                "sha256:e61ceaab6f49fb8bdfaa0f92c4b57bcfbea54c09277b1b4f7ac376bfb7a7c174",
+                "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"
+            ],
+            "index": "pypi",
+            "version": "==6.0"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983",
+                "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"
+            ],
+            "index": "pypi",
+            "version": "==2.28.1"
+        },
+        "six": {
+            "hashes": [
+                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.16.0"
+        },
+        "soupsieve": {
+            "hashes": [
+                "sha256:3b2503d3c7084a42b1ebd08116e5f81aadfaea95863628c80a3b774a11b7c759",
+                "sha256:fc53893b3da2c33de295667a0e19f078c14bf86544af307354de5fcf12a3f30d"
+            ],
+            "markers": "python_full_version >= '3.6.0'",
+            "version": "==2.3.2.post1"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02",
+                "sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==4.3.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:8298d6d56d39be0e3bc13c1c97d133f9b45d797169a0e11cdd0e0489d786f7ec",
+                "sha256:879ba4d1e89654d9769ce13121e0f94310ea32e8d2f8cf587b77c08bbcdb30d6"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_version < '4'",
+            "version": "==1.26.10"
+        }
+    },
+    "develop": {}
+}

--- a/README.md
+++ b/README.md
@@ -25,35 +25,29 @@ make scrape
 
 ### Setup python venv
 
-Create a python virtual environment:
+Install [pipenv](https://pipenv.pypa.io/en/latest/basics/):
 
 ```
-python3 -m venv venv
+pip3 install pipenv
 ```
 
 
-Activate the venv:
+Install all the dependencies
 
 ```
-source venv/bin/activate
+pipenv install -d
 ```
 
-or use any other `activate` file that would match your shell, for example if you're using `fish`:
+Activate your pipenv shell:
 
 ```
-source venv/bin/activate.fish
-```
-
-Then install the dependecies:
-
-```
-pip install -r requirements.txt
+pipenv shell
 ```
 
 
 ### Run
 
-Make sure you have activated the virtual envirnoment, running `which python` should point to the binary inside the `venv` dir.
+Make sure you have activated the pipenv virtual envirnoment, running `which python` should point to the binary inside the pipenv `venv` dir.
 
 
 Run the script from the root dir:
@@ -74,4 +68,3 @@ Example:
 ```
 LOG_LVL=1 LATEST_ONLY=1 python scraper.py
 ```
-

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,16 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.provider "libvirt" do |lv,override|
+    override.vm.box = "generic/ubuntu2204"
+    override.vm.synced_folder ".", "/vagrant/"
+  end
+  config.vm.box = "bento/ubuntu-22.04"
+  config.vm.provision "shell", inline: <<-SHELL
+    export DEBIAN_FRONTEND='noninteractive'
+    apt-get update &&
+      apt-get install -y python3-pip &&
+      pip3 install pipenv
+  SHELL
+end

--- a/models/config.py
+++ b/models/config.py
@@ -1,0 +1,17 @@
+from typing import Dict, List
+from pydantic.dataclasses import dataclass as py_dataclass
+from pydantic import HttpUrl
+
+
+@py_dataclass
+class ShowDetails:
+    fireside_url: HttpUrl
+    fireside_slug: str
+    jb_url: HttpUrl
+    acronym: str
+    name: str
+
+@py_dataclass
+class ConfigData:
+    shows: Dict[str,ShowDetails]
+    usernames_map: Dict[str,str]

--- a/models/episode.py
+++ b/models/episode.py
@@ -2,11 +2,23 @@ from datetime import datetime, time
 import json
 from textwrap import indent
 from typing import Dict, List, Literal, Optional
+from uuid import UUID
 from pydantic import BaseModel, AnyHttpUrl, HttpUrl, Json, root_validator, validator
+from pydantic.dataclasses import dataclass as py_dataclass
 
 
+# FIXME: make this a class variable under Episode
+# https://github.com/samuelcolvin/pydantic/issues/184#issuecomment-392566460
 VALID_YOUTUBE_HOSTNAMES = {"youtube.com", "www.youtube.com", "youtu.be",  "www.youtu.be"}
 
+
+# for example:
+# https://feeds.fireside.fm/selfhosted/json/episodes/a9a4f084-47ba-490c-a65b-cef65719182d/chapters
+@py_dataclass
+class FsChapters:
+    """
+    """
+    pass
 
 class Episode(BaseModel):
 
@@ -31,7 +43,7 @@ class Episode(BaseModel):
 
     # Episode GUID
     # Source: Fireside json api: `items[n].id`
-    episode_guid: str
+    episode_guid: UUID
 
     # Episode number again, but specifically for Hugo.
     # Need this since we want to have zero padded filenames (e.g. `0042.md`), but no 
@@ -89,6 +101,8 @@ class Episode(BaseModel):
     # Chapters JSON in a format defined by podcastingindex.org:
     #   https://github.com/Podcastindex-org/podcast-namespace/blob/main/chapters/jsonChapters.md
     # Source: RSS feed from fireside
+    # TODO: implement
+    # podcast_chapters: Optional[FsChapters]
     podcast_chapters: Optional[Dict]
 
     # Has different tracking url than `podcast_file`

--- a/models/fireside.py
+++ b/models/fireside.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Dict, List
+from typing import List
 from uuid import UUID
 from pydantic.dataclasses import dataclass as py_dataclass
 from pydantic import AnyHttpUrl, BaseModel, Extra, Field, HttpUrl, PositiveInt

--- a/models/fireside.py
+++ b/models/fireside.py
@@ -1,0 +1,44 @@
+from datetime import datetime
+from typing import Dict, List
+from uuid import UUID
+from pydantic.dataclasses import dataclass as py_dataclass
+from pydantic import AnyHttpUrl, BaseModel, Extra, Field, HttpUrl, PositiveInt
+
+@py_dataclass
+class FsShowItemAttachment:
+    url: HttpUrl
+    mime_type: str
+    size_in_bytes: PositiveInt
+    duration_in_seconds: PositiveInt
+
+@py_dataclass
+class FsShowItem:
+    id: UUID
+    title: str
+    url: HttpUrl
+    content_text: str
+    content_html: str
+    summary: str
+    date_published: datetime
+    attachments: List[FsShowItemAttachment]
+
+@py_dataclass
+class PrivateFireside:
+    subtitle: str
+    pubdate: datetime
+    explicit: bool
+    copyright: str
+    owner: str
+    image: AnyHttpUrl
+
+class ShowJson(BaseModel):
+    # https://stackoverflow.com/a/71838453
+    class Config:
+        extra = Extra.forbid
+    version: HttpUrl
+    title: str
+    home_page_url: HttpUrl
+    feed_url: HttpUrl
+    description: str
+    fireside: PrivateFireside = Field(None, alias='_fireside')
+    items: List[FsShowItem]

--- a/models/misc.py
+++ b/models/misc.py
@@ -19,3 +19,4 @@ class Jbd_Episode_Record:
     hd_video: Optional[HttpUrl] = None
     mobile_video: Optional[HttpUrl] = None
     youtube: Optional[HttpUrl] = None
+    torrent: Optional[HttpUrl] = None

--- a/models/misc.py
+++ b/models/misc.py
@@ -4,7 +4,7 @@ from pydantic import AnyHttpUrl, HttpUrl
 from pydantic.dataclasses import dataclass as py_dataclass
 
 @py_dataclass
-class Jbd_Episode_Record:
+class Jb_Episode_Record:
     """
     JBDATA_Episode_Record
     for the JB_DATA dictionary of {<show>:{<episode_number>:{<this_info>}}}
@@ -20,3 +20,4 @@ class Jbd_Episode_Record:
     mobile_video: Optional[HttpUrl] = None
     youtube: Optional[HttpUrl] = None
     torrent: Optional[HttpUrl] = None
+    hd_torrent: Optional[HttpUrl] = None

--- a/models/misc.py
+++ b/models/misc.py
@@ -1,0 +1,21 @@
+from json import JSONEncoder
+from typing import Any, Dict, List, Optional
+from pydantic import AnyHttpUrl, HttpUrl
+from pydantic.dataclasses import dataclass as py_dataclass
+
+@py_dataclass
+class Jbd_Episode_Record:
+    """
+    JBDATA_Episode_Record
+    for the JB_DATA dictionary of {<show>:{<episode_number>:{<this_info>}}}
+    """
+    # have to mark all optional, because they are populated at various times
+    jb_url: Optional[HttpUrl] = None
+    # Using AnyHttpUrl, because these tend to be longer and there
+    #   is a hard cap on length of 2083 for HttpUrl
+    mp3_audio: Optional[AnyHttpUrl] = None
+    ogg_audio: Optional[HttpUrl] = None
+    video: Optional[HttpUrl] = None
+    hd_video: Optional[HttpUrl] = None
+    mobile_video: Optional[HttpUrl] = None
+    youtube: Optional[HttpUrl] = None

--- a/models/person.py
+++ b/models/person.py
@@ -7,7 +7,7 @@ class Person(BaseModel):
 
     type: PersonType
     username: str  # Unique ID
-    name: str
+    title: str
     bio: Optional[str]
     avatar: Optional[str]
     avatar_small: Optional[str]

--- a/models/sponsor.py
+++ b/models/sponsor.py
@@ -4,6 +4,6 @@ from pydantic import BaseModel, HttpUrl, root_validator
 
 class Sponsor(BaseModel):
     shortname: str
-    name: str
+    title: str
     description: str
     link: HttpUrl

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,0 @@
-beautifulsoup4==4.9.3
-requests==2.25.1
-html2text==2020.1.16
-pyyaml==5.4.1
-python-dateutil==2.8.2
-loguru==0.6.0
-pydantic==1.9.1

--- a/scraper.py
+++ b/scraper.py
@@ -860,5 +860,4 @@ if __name__ == "__main__":
     logger.info("🚀🚀🚀 SCRAPER STARTED! 🚀🚀🚀")
     main()
     logger.success("🔥🔥🔥 ALL DONE :) 🔥🔥🔥\n\n")
-    # logger.debug(json.dumps(JB_DATA, default=pydantic_encoder))
     exit(0)

--- a/scraper.py
+++ b/scraper.py
@@ -24,6 +24,7 @@ from models.fireside import FsShowItem, FsShowItemAttachment, ShowJson
 from models.misc import Jb_Episode_Record
 from models.person import PersonType
 from frontmatter import Post, dumps as f_dumps
+# DO NOT REMOVE, even though not used. (JupiterBroadcasting/show-scraper #21)
 from pydantic_yaml import YamlModelMixin
 
 

--- a/scraper.py
+++ b/scraper.py
@@ -666,7 +666,7 @@ def scrape_show_hosts(shows: Dict[str, ShowDetails] , executor) -> Dict[str, Per
             avatar = save_avatar_img(avatar_url, username)
 
             append_person_to_dict("host", show_hosts, username, show_data.acronym,
-                                  name=name,
+                                  title=name,
                                   avatar="/"+avatar,
                                   avatar_small="/"+avatar_small,
                                   bio=bio,
@@ -705,7 +705,7 @@ def scrape_show_guests(shows: Dict[str, ShowDetails], executor) -> Dict[str, Per
             page_data = parse_person_page(html_page)
 
             append_person_to_dict("guest", show_guests, username, show_data.acronym,
-                                  name=name,
+                                  title=name,
                                   avatar="/"+avatar,
                                   avatar_small="/"+avatar_small,
                                   **page_data)

--- a/scraper.py
+++ b/scraper.py
@@ -19,7 +19,7 @@ from loguru import logger
 from models import Episode, Person, Sponsor
 from models.config import ConfigData, ShowDetails
 from models.fireside import FsShowItem, FsShowItemAttachment, ShowJson
-from models.misc import Jbd_Episode_Record
+from models.misc import Jb_Episode_Record
 from models.person import PersonType
 
 
@@ -60,7 +60,7 @@ SPONSORS: Dict[str, Sponsor] = {}  # JSON filename as key (e.g. "linode.com-lup.
 #     "show_slug_2": { ... }
 # }
 JB_DATA = {}
-JB_DATA: Dict[str, Dict[int, Jbd_Episode_Record]]
+JB_DATA: Dict[str, Dict[int, Jb_Episode_Record]]
 
 CHAPTERS_URL_TPL = "https://feeds.fireside.fm/{show}/json/episodes/{ep_id}/chapters"
 
@@ -160,7 +160,7 @@ def create_episode(api_episode: FsShowItem,
         #   so informed about issues like GH issue 16
         jb_ep_data = JB_DATA.get(show_slug).get(episode_number)
         # logger.debug(f"{episode_number} jb_ep_data: {jb_ep_data}")
-        jb_ep_data: Jbd_Episode_Record
+        jb_ep_data: Jb_Episode_Record
         # TODO: handle this use case:
         # https://github.com/JupiterBroadcasting/show-scraper/issues/16#issuecomment-1196751641
         try:
@@ -176,7 +176,7 @@ def create_episode(api_episode: FsShowItem,
                              f"episode_url: {api_episode.url}\n"
                              f"data we have: {jb_ep_data}\n"
                              f"error: {errorz}")
-            jb_ep_data = Jbd_Episode_Record()
+            jb_ep_data = Jb_Episode_Record()
             jb_url = None
 
         if jb_url:
@@ -435,7 +435,7 @@ def scrape_data_from_jb(shows: Dict[str,ShowDetails], executor):
     for future in concurrent.futures.as_completed(futures):
         page_content, ep_data, show, ep = future.result()
         page_content: requests.Response
-        ep_data: Jbd_Episode_Record
+        ep_data: Jb_Episode_Record
         show: str # episode slug
         ep: int # episode number
 
@@ -445,14 +445,14 @@ def scrape_data_from_jb(shows: Dict[str,ShowDetails], executor):
     # save_json_file("jb_all_shows_links.json", JB_DATA, DATA_ROOT_DIR)
     logger.success(">>> Finished scraping data from jupiterbroadcasting.com")
 
-def jb_get_ep_page_content(page_url: HttpUrl, ep_data: Jbd_Episode_Record, show: str, ep: int)-> Tuple[requests.Response, Dict, str, int]:
+def jb_get_ep_page_content(page_url: HttpUrl, ep_data: Jb_Episode_Record, show: str, ep: int)-> Tuple[requests.Response, Dict, str, int]:
     """
     returns a tuple with the page's content, Jbd_Episode_Record, show slug, and episode number
     """
     resp = requests.get(page_url)
     return resp, ep_data, show, ep
 
-def jb_populate_direct_links_for_episode(ep_page_content: requests.Response, ep_data: Jbd_Episode_Record, show: str, ep: int) -> None:
+def jb_populate_direct_links_for_episode(ep_page_content: requests.Response, ep_data: Jb_Episode_Record, show: str, ep: int) -> None:
     """
     this populates the rest of the Jbd_Episode_Record object with direct
     download links to various services (YouTube, OGG audio, etc..).
@@ -571,7 +571,7 @@ def jb_populate_episodes_urls(show_slug: str, show_base_url: HttpUrl) -> None:
                 if ep_num in show_data.keys():
                     raise ValueError(f"There is already an existing show for episode number: {ep_num}\nWhich is: {show_data[ep_num]}\nCurrent attempted info: {item.contents}\nAll current info: {JB_DATA}")
 
-                show_data.update({ep_num: Jbd_Episode_Record(jb_url=link_href)})
+                show_data.update({ep_num: Jb_Episode_Record(jb_url=link_href)})
             except Exception as e:
                 logger.exception(
                     "Failed to get episode page link and number from JB site.\n"

--- a/scraper.py
+++ b/scraper.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import concurrent.futures
 import json
 import os

--- a/scraper.py
+++ b/scraper.py
@@ -4,7 +4,7 @@ import concurrent.futures
 import json
 import os
 import sys
-from typing import Dict, List, Literal
+from typing import Dict, List
 from urllib.error import HTTPError
 from urllib.parse import urlparse
 
@@ -768,7 +768,7 @@ def main():
 
 
 if __name__ == "__main__":
-    LOG_LVL = int(os.getenv("LOG_LVL", 20))  # Defaults to INFO
+    LOG_LVL = int(os.getenv("LOG_LVL", 20))  # Defaults to INFO, 10 for debug
     logger.remove()  # Remove default logger
     logger.add(sys.stderr, level=LOG_LVL)
 

--- a/scraper.py
+++ b/scraper.py
@@ -329,7 +329,7 @@ def parse_sponsors(api_soup: BeautifulSoup, page_soup: BeautifulSoup, show: str,
                 SPONSORS.update({
                     filename: Sponsor(
                         shortname=shortname,
-                        name=sponsor_a.find("header").text.strip(),
+                        title=sponsor_a.find("header").text.strip(),
                         description=sponsor_a.find("p").text.strip(),
                         link=sl
                     )

--- a/scraper.py
+++ b/scraper.py
@@ -474,10 +474,16 @@ def jb_populate_direct_links_for_episode(ep_page_content: requests.Response, ep_
                     f"  ep: {ep}")
                 return
 
+    # this uses the resulting anchor tags and creates them dyanmically based on text
         for dl_link in dl_links:
             url = dl_link.get("href").strip("\\\"")
             slug = dl_link.text.lower().replace(" ", "_")
-            setattr(ep_data, slug, url)
+
+            # check if it's a defined property on the dataclass
+            if slug in ep_data.__match_args__:
+                setattr(ep_data, slug, url)
+                continue
+            logger.error(f"New field {slug} (value of: {url}) is not already explicitly defined in the Jbd_Episode_Record")
     except Exception as e:
         logger.exception(
             "Failed to parse direct links for episode.\n"

--- a/scraper.py
+++ b/scraper.py
@@ -159,6 +159,8 @@ def create_episode(api_episode,
         jb_ep_data = JB_DATA.get(show_slug).get(episode_number)
         # logger.debug(f"{episode_number} jb_ep_data: {jb_ep_data}")
         jb_ep_data: Jbd_Episode_Record
+        # TODO: handle this use case:
+        # https://github.com/JupiterBroadcasting/show-scraper/issues/16#issuecomment-1196751641
         try:
             jb_url = jb_ep_data.jb_url
         except AttributeError as errorz:
@@ -168,7 +170,10 @@ def create_episode(api_episode,
             #   this means that we're just pulling info directly
             #   from fireside and have no direct downloads
             logger.exception("Show won't have direct download links!\n"
-                             f"episode_url: {api_episode.get('url')}")
+                             f"episode_url: {api_episode.get('url')}\n"
+                             f"data we have: {jb_ep_data}\n"
+                             f"error: {errorz}")
+            jb_ep_data = Jbd_Episode_Record()
             jb_url = None
             # raise errorz
         if jb_url:
@@ -818,7 +823,7 @@ def main():
         config = yaml.load(f, Loader=yaml.SafeLoader)
         validated_config = ConfigData(shows=config['shows'], usernames_map=config['usernames_map'])
 
-    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+    with concurrent.futures.ThreadPoolExecutor() as executor:
         # Must be first. Here the JB_DATA global is populated
         scrape_data_from_jb(validated_config.shows, executor)
 

--- a/scraper.py
+++ b/scraper.py
@@ -146,7 +146,7 @@ def create_episode(api_episode: FsShowItem,
         for link in page_soup.find_all("a", class_="tag"):
             _tag = link.get_text().strip()
             # escape inner quotes (occurs in coderradio 434)
-            _tag = _tag.replace("\"", "\\\"")
+            _tag = _tag.replace('"', r'\"')
             tags.append(_tag)
 
         tags = sorted(tags)
@@ -171,8 +171,9 @@ def create_episode(api_episode: FsShowItem,
             #   deosn't get used in the new website.
             #   this means that we're just pulling info directly
             #   from fireside and have no direct downloads
-            logger.exception("Show won't have direct download links!\n"
-                             f"episode_url: {api_episode.get('url')}\n"
+            logger.warning("Show won't have direct download links!\n")
+            logger.debug("Show won't have direct download links!\n"
+                             f"episode_url: {api_episode.url}\n"
                              f"data we have: {jb_ep_data}\n"
                              f"error: {errorz}")
             jb_ep_data = Jbd_Episode_Record()
@@ -264,7 +265,7 @@ def parse_hosts_in_ep(page_soup: BeautifulSoup, show_config: ShowDetails, ep: in
     return episode_hosts
 
 
-def parse_guests_in_ep(page_soup, show_config: ShowDetails, ep):
+def parse_guests_in_ep(page_soup: BeautifulSoup, show_config: ShowDetails, ep: int):
     show = show_config.acronym
     base_url = show_config.fireside_url
 


### PR DESCRIPTION
Part of addressing this: https://github.com/JupiterBroadcasting/jupiterbroadcasting.com/issues/110

Alright, everything's working now :grin: 

NOTE: This **can't** be merged till I make the appropriate changes to utilize the new logic, or else it'll break the update flow that we've got with the GH action.

Summary of changes:
- this actually could close #12 instead of that PR, I can remove those commits if we want or just add the requirements.txt back till we figure out #12 
- I've added 2 more packages `python-frontmatter` & `pydantic-yaml`
- adding more typing to help validate/ensure some of the information we're ingesting/consuming from various locations (even the config)
  - part of this was defining what chapters look like per the spec
  - this also caused a lot of dictionaries to not be addressable as objects i.e. `example_data['foo']` -> `example_data.foo`
- migrated people & sponsors objects which were writing to `data/` to now use `content/` and writing as `.md` instead of `.json`
  - I used yaml for the frontmatter, because the output for json & toml isn't as well supported in the `python-frontmatter` library, and with `pydantic-yaml` doing a lot of the heavy lifting for ease of conversion, it just works :sweat_smile:
- documenting code more with docstrings
- added some more checks if there were unexpected info, and logging errors if they are
- simplifying show_exceptions for the `jb_populate_episodes_urls` function