### PR TITLE
[model/person] change username to mumble_username

### DIFF
--- a/models/person.py
+++ b/models/person.py
@@ -6,7 +6,7 @@ PersonType = Literal["host", "guest"]
 class Person(BaseModel):
 
     type: PersonType
-    username: str  # Unique ID
+    mumble_username: str  # Unique ID
     title: str
     bio: Optional[str]
     avatar: Optional[str]


### PR DESCRIPTION
Username is very non-specific, so change it to a specific one, in this case Mumble Username as that makes the most sense.

I'm not sure if all the guest markdown pages needs to be manually changed to use this one, as they all just have `username` right now, so the field might not get transferred automatically.

Signed-off-by: Dan Johansen <strit@manjaro.org>