### PR TITLE
prevent override alex's profile from over-writing

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -66,3 +66,4 @@ data_dont_override:
   - chzbacon.md
   - ell.md
   - danjohansen.md
+  - alex.md


### PR DESCRIPTION
related: https://github.com/JupiterBroadcasting/jupiterbroadcasting.com/pull/373/

since modification, we're wanting to not have the scraper over-writing his profile