### PR TITLE
Escape title attribute from anchor tags in show links

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -152,6 +152,9 @@ def create_episode(api_episode: FsShowItem,
             api_soup, page_soup, show_config.acronym, episode_number)
 
         links_list = get_list(api_soup, "Links:") or get_list(api_soup, "Episode Links:")
+        # Remove title attr from anchors, they are not used in Markdown and cause formatting issues
+        for link in links_list.find_all('a'):
+            del link['title']
         links = html2text(str(links_list)) if links_list else None
 
         tags = []

--- a/scraper.py
+++ b/scraper.py
@@ -9,6 +9,7 @@ import re
 from typing import Dict, List, Optional, Tuple, Union
 from urllib.error import HTTPError
 from urllib.parse import urlparse
+from html import escape
 
 from html2text import html2text
 from pydantic import HttpUrl, PositiveInt
@@ -152,9 +153,8 @@ def create_episode(api_episode: FsShowItem,
             api_soup, page_soup, show_config.acronym, episode_number)
 
         links_list = get_list(api_soup, "Links:") or get_list(api_soup, "Episode Links:")
-        # Remove title attr from anchors, they are not used in Markdown and cause formatting issues
         for link in links_list.find_all('a'):
-            del link['title']
+            link['title'] = escape(link['title'])
         links = html2text(str(links_list)) if links_list else None
 
         tags = []


### PR DESCRIPTION
~~Remove the title attribute as it is not used in Markdown and can cause formatting issues.~~

Edit: Escaping the title will fix the double quotes causing issues with the title in Markdown.